### PR TITLE
Fix go.mod by adding go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module github.com/garyjg/shapepuzzle
+
+go 1.18


### PR DESCRIPTION
Currently the go.mod file is not valid as it does not have a go directive mentioning the version. I've added one.